### PR TITLE
Removing preceding whitespace in Peak Wind Gust type for S2120

### DIFF
--- a/S2120/ChirpStack/SenseCAP_S2120_ChirpStackV3_Decoder.js
+++ b/S2120/ChirpStack/SenseCAP_S2120_ChirpStackV3_Decoder.js
@@ -352,7 +352,7 @@ function dataIdAndDataValueJudge(dataId, dataValue) {
       messages = [{
         measurementValue: loraWANV2DataFormat(peakWind, 10),
         measurementId: '4191',
-        type: ' Peak Wind Gust'
+        type: 'Peak Wind Gust'
       }, {
         measurementValue: loraWANV2DataFormat(rainAccumulation, 1000),
         measurementId: '4213',

--- a/S2120/Helium/SenseCAP_S2120_Helium_Decoder.js
+++ b/S2120/Helium/SenseCAP_S2120_Helium_Decoder.js
@@ -526,7 +526,7 @@ function Decoder (bytes, port) {
         peakWind = dataValue.substring(0, 4)
         rainAccumulation = dataValue.substring(4, 12)
         messages = [{
-          measurementValue: loraWANV2DataFormat(peakWind, 10), measurementId: '4191', type: ' Peak Wind Gust'
+          measurementValue: loraWANV2DataFormat(peakWind, 10), measurementId: '4191', type: 'Peak Wind Gust'
         }, {
           measurementValue: loraWANV2DataFormat(rainAccumulation, 1000), measurementId: '4213', type: 'Rain Accumulation'
         }]

--- a/S2120/TTN/SenseCAP_S2120_TTN_Decoder.js
+++ b/S2120/TTN/SenseCAP_S2120_TTN_Decoder.js
@@ -313,7 +313,7 @@ function dataIdAndDataValueJudge (dataId, dataValue) {
       peakWind = dataValue.substring(0, 4)
       rainAccumulation = dataValue.substring(4, 12)
       messages = [{
-        measurementValue: loraWANV2DataFormat(peakWind, 10), measurementId: '4191', type: ' Peak Wind Gust'
+        measurementValue: loraWANV2DataFormat(peakWind, 10), measurementId: '4191', type: 'Peak Wind Gust'
       }, {
         measurementValue: loraWANV2DataFormat(rainAccumulation, 1000), measurementId: '4213', type: 'Rain Accumulation'
       }]


### PR DESCRIPTION
S2120 decoder for recently added Peak Wind Gust erroneously included whitespace in the type. This Pull Request removes the whitespace for all three decoders. 